### PR TITLE
Set up logging earlier in the boot process

### DIFF
--- a/lib/rails_stdout_logging/railtie.rb
+++ b/lib/rails_stdout_logging/railtie.rb
@@ -2,7 +2,7 @@ require 'rails_stdout_logging/rails3'
 
 module RailsStdoutLogging
   class Railtie < ::Rails::Railtie
-    config.after_initialize do
+    config.before_initialize do
       Rails3.set_logger(config)
     end
   end


### PR DESCRIPTION
This fixes an issue where the ActionPack loggers do not write to STDOUT.

To reproduce:

``` ruby
class TestController < ApplicationController
  def index
    Rails.logger.info "Logging with Rails.logger" # Printed to STDOUT
    logger.info "Logging with logger"             # Not printed to STDOUT
  end
end
```

The ActionPack classes are set up by Railties initializers, including
setting the logger to Rails.logger. We need to set up the STDOUT logging
before the Railties initializers run, otherwise the loggers will be set
to the default Rails logger.
