### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Then run
 $ bundle install`
 ```
 
-You also need the `rails_serve_static_assets` gem. You can get both of them together by installing `rails_on_heroku` gem.
+You also need the [`rails_serve_static_assets` gem](https://github.com/heroku/rails_serve_static_assets).
+You can get both of them together by installing the [`rails_12factor` gem](https://github.com/heroku/rails_12factor).
 
 ## Why is this needed?
 


### PR DESCRIPTION
- Replace the deprecated `rails_on_heroku` gem with the `rails_12factor` gem
- Link to the repos of the `rails_serve_static_assets` and `rails_12factor` gems
