### PR TITLE
Include Rails 4 logger silence module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 rvm:
+  - 2.2
+  - 2.1
   - 2.0.0
   - 1.9.3
 
@@ -8,3 +10,20 @@ gemfile:
   - gemfiles/rails_3.1.x.gemfile
   - gemfiles/rails_3.2.x.gemfile
   - gemfiles/rails_4.0.x.gemfile
+  - gemfiles/rails_4.1.x.gemfile
+  - gemfiles/rails_4.2.x.gemfile
+
+matrix:
+  exclude:
+    - rvm: 2.1
+      gemfile: gemfiles/rails_3.0.x.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/rails_3.1.x.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/rails_3.2.x.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails_3.0.x.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails_3.1.x.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails_3.2.x.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -13,3 +13,11 @@ end
 appraise "rails-4.0.x" do
   gem "rails", "~> 4.0.0"
 end
+
+appraise "rails-4.1.x" do
+  gem "rails", "~> 4.1.0"
+end
+
+appraise "rails-4.2.x" do
+  gem "rails", "~> 4.2.0"
+end

--- a/gemfiles/rails_3.0.x.gemfile
+++ b/gemfiles/rails_3.0.x.gemfile
@@ -6,8 +6,8 @@ gem "appraisal"
 gem "rake"
 gem "capybara"
 gem "launchy"
-gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
-gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform=>:jruby
+gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
+gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform => :jruby
 gem "rails", "~> 3.0.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_3.2.x.gemfile
+++ b/gemfiles/rails_3.2.x.gemfile
@@ -6,8 +6,8 @@ gem "appraisal"
 gem "rake"
 gem "capybara"
 gem "launchy"
-gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
-gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform=>:jruby
+gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
+gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform => :jruby
 gem "rails", "~> 3.2.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_4.0.x.gemfile
+++ b/gemfiles/rails_4.0.x.gemfile
@@ -6,8 +6,8 @@ gem "appraisal"
 gem "rake"
 gem "capybara"
 gem "launchy"
-gem "sqlite3", :platform=>[:ruby, :mswin, :mingw]
-gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform=>:jruby
+gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
+gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform => :jruby
 gem "rails", "~> 4.0.0"
 
-gemspec :path=>"../"
+gemspec :path => "../"

--- a/gemfiles/rails_4.1.x.gemfile
+++ b/gemfiles/rails_4.1.x.gemfile
@@ -8,6 +8,6 @@ gem "capybara"
 gem "launchy"
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
 gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform => :jruby
-gem "rails", "~> 3.1.0"
+gem "rails", "~> 4.1.0"
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.x.gemfile
+++ b/gemfiles/rails_4.2.x.gemfile
@@ -8,6 +8,6 @@ gem "capybara"
 gem "launchy"
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
 gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform => :jruby
-gem "rails", "~> 3.1.0"
+gem "rails", "~> 4.2.0"
 
 gemspec :path => "../"

--- a/lib/rails_stdout_logging/rails.rb
+++ b/lib/rails_stdout_logging/rails.rb
@@ -1,9 +1,13 @@
 module RailsStdoutLogging
+  class StdoutLogger < ::Logger
+    include ::LoggerSilence if defined?(::LoggerSilence)
+  end
+
   class Rails
     def self.heroku_stdout_logger
-      logger       = Logger.new(STDOUT)
+      logger       = StdoutLogger.new(STDOUT)
       logger       = ActiveSupport::TaggedLogging.new(logger) if defined?(ActiveSupport::TaggedLogging)
-      logger.level = Logger.const_get(log_level)
+      logger.level = StdoutLogger.const_get(log_level)
       logger
     end
 

--- a/test/dummy/app/controllers/bar_controller.rb
+++ b/test/dummy/app/controllers/bar_controller.rb
@@ -1,10 +1,13 @@
 ## This controller uses includes
 
 class BarController < ApplicationController
-
   def index
     Rails.logger.info "Logging with Rails.logger" # Printed to STDOUT
     logger.info "Logging with logger"             # Not printed to STDOUT
+
+    Rails.logger.silence {
+      Rails.logger.info "This should not be logged!"
+    }
   end
 
   def update

--- a/test/integration/controller_logging_test.rb
+++ b/test/integration/controller_logging_test.rb
@@ -5,5 +5,6 @@ class ControllerLoggingTest < ActiveSupport::IntegrationCase
     visit bar_index_path
     assert_match "Logging with Rails.logger", STDOUT.string
     assert_match "Logging with logger",       STDOUT.string
+    assert_no_match(/This should not be logged!/, STDOUT.string)
   end
 end


### PR DESCRIPTION
Fixes #14, please read there for more context.

I've also updated the appraisals to add Rails 4.1/4.2 and Ruby 2.1/2.2 - but excluded those with older versions of Rails from the travis build - they are likely to fail anyway.

Let me know if there's anything that needs improving.