### PR TITLE
Fix double logging when `heroku run rails console`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem install bundler
 rvm:
   - 2.2
   - 2.1

--- a/lib/rails_stdout_logging/railtie.rb
+++ b/lib/rails_stdout_logging/railtie.rb
@@ -5,5 +5,9 @@ module RailsStdoutLogging
     config.before_initialize do
       Rails3.set_logger(config)
     end
+
+    console do
+      ::Rails.logger.instance_variable_set(:@level, Float::INFINITY)
+    end
   end
 end


### PR DESCRIPTION
Rails console is logging to `STDOUT` but heroku StdoutLogger does it too.
«There can be only one!».
