### PR TITLE
adding reader method in `RailsStdoutLogging` for compatible Rails5

### DIFF
--- a/lib/rails_stdout_logging/rails.rb
+++ b/lib/rails_stdout_logging/rails.rb
@@ -1,6 +1,7 @@
 module RailsStdoutLogging
   class StdoutLogger < ::Logger
     include ::LoggerSilence if defined?(::LoggerSilence)
+    attr_reader :level
   end
 
   class Rails


### PR DESCRIPTION
see what exactly happen in Rails5 beta2.

```
$ rails s
=> Booting Puma
=> Rails 5.0.0.beta2 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
/your/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.0.beta2/lib/active_support/logger_silence.rb:23:in `level': undefined method `[]' for nil:NilClass (NoMethodError)
    from /your/app/vendor/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/server.rb:140:in `log_to_stdout'
    from /your/app/vendor/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/server.rb:76:in `start'
    from /your/app/vendor/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:90:in `block in server'
    from /your/app/vendor/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:85:in `tap'
    from /your/app/vendor/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:85:in `server'
    from /your/app/vendor/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
    from /your/app/vendor/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/command.rb:20:in `run'
    from /your/app/vendor/bundle/ruby/2.3.0/gems/railties-5.0.0.beta2/lib/rails/commands.rb:19:in `<top (required)>'
    from bin/rails:4:in `require'
    from bin/rails:4:in `<main>'
```
