### PR TITLE
follow LoggerSilence changes

### DIFF
--- a/lib/rails_stdout_logging/rails.rb
+++ b/lib/rails_stdout_logging/rails.rb
@@ -1,6 +1,16 @@
 module RailsStdoutLogging
   class StdoutLogger < ::Logger
     include ::LoggerSilence if defined?(::LoggerSilence)
+
+    def initialize(*args)
+      super
+      after_initialize if respond_to? :after_initialize
+    end
+
+    def add(severity, message = nil, progname = nil, &block)
+      return true if @logdev.nil? || (severity || ::Logger::UNKNOWN) < level
+      super
+    end
   end
 
   class Rails


### PR DESCRIPTION
* `LoggerSilence` have to invoke after_initialize. (from activesupport v4.2.6)
https://github.com/rails/rails/blob/v4.2.6/activesupport/lib/active_support/logger_silence.rb#L14

* `@level` instance variable is not change at `LoggerSilence.silence` block. (from activesupport v4.2.6)
https://github.com/rails/rails/blob/v4.2.6/activesupport/lib/active_support/logger_silence.rb#L31
https://github.com/ruby/ruby/blob/trunk/lib/logger.rb#L421
