### PR TITLE
Fix Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.0.0
   - 1.9.3
 
+before_install:
+  - gem install bundler -v '~> 1.11'
+
 gemfile:
   - gemfiles/rails_3.0.x.gemfile
   - gemfiles/rails_3.1.x.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.3.0
   - 2.2
   - 2.1
   - 2.0.0
@@ -30,4 +31,10 @@ matrix:
     - rvm: 2.2
       gemfile: gemfiles/rails_3.1.x.gemfile
     - rvm: 2.2
+      gemfile: gemfiles/rails_3.2.x.gemfile
+    - rvm: 2.3.0
+      gemfile: gemfiles/rails_3.0.x.gemfile
+    - rvm: 2.3.0
+      gemfile: gemfiles/rails_3.1.x.gemfile
+    - rvm: 2.3.0
       gemfile: gemfiles/rails_3.2.x.gemfile


### PR DESCRIPTION
### 1. Update bundler before installing gems

The default bundler included in Travis CI Ruby environments is too old
and contains a bug that triggers a failure and prevents testing.

Refs: bundler/bundler#3558 travis-ci/travis-ci#3531

### 2. Using container-based infrastructure

Jobs running on container-based infrastructure:

1. start up faster
2. allow the use of caches for public repositories
3. disallow the use of `sudo`, setuid and setgid executables

### 3. Test against Ruby 2.3

Teeny component for this Ruby version is needed by Travis CI to properly run tests