### PR TITLE
Use AS::Logger instead of Logger if available

### DIFF
--- a/lib/rails_stdout_logging/rails.rb
+++ b/lib/rails_stdout_logging/rails.rb
@@ -1,5 +1,5 @@
 module RailsStdoutLogging
-  class StdoutLogger < ::Logger
+  class StdoutLogger < defined?(::ActiveSupport::Logger) ? ::ActiveSupport::Logger : ::Logger
     include ::LoggerSilence if defined?(::LoggerSilence)
   end
 


### PR DESCRIPTION
Use AS::Logger instead of Logger if available

ActiveSupport::LoggerThreadSafeLevel does not work with stdlib ::Logger
without monkeypatching. rails/rails#24263 introduced thread safety but
requires the target class to implement code to call an after_initialize
method if it exists. ActiveSupport::Logger has those modules included
and the correct interface implemented.

Fix #23

Refs: rails/rails#24263 heroku/rails_stdout_logging#22