### PR TITLE
Fix Ruby 1.9 / Rails 4.x Travis CI build

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -12,12 +12,15 @@ end
 
 appraise "rails-4.0.x" do
   gem "rails", "~> 4.0.0"
+  gem "mime-types", "< 3.0", platform: [:mri_19]
 end
 
 appraise "rails-4.1.x" do
   gem "rails", "~> 4.1.0"
+  gem "mime-types", "< 3.0", platform: [:mri_19]
 end
 
 appraise "rails-4.2.x" do
   gem "rails", "~> 4.2.0"
+  gem "mime-types", "< 3.0", platform: [:mri_19]
 end

--- a/gemfiles/rails_4.0.x.gemfile
+++ b/gemfiles/rails_4.0.x.gemfile
@@ -9,5 +9,6 @@ gem "launchy"
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
 gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform => :jruby
 gem "rails", "~> 4.0.0"
+gem "mime-types", "< 3.0", :platform => [:mri_19]
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.1.x.gemfile
+++ b/gemfiles/rails_4.1.x.gemfile
@@ -9,5 +9,6 @@ gem "launchy"
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
 gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform => :jruby
 gem "rails", "~> 4.1.0"
+gem "mime-types", "< 3.0", :platform => [:mri_19]
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.x.gemfile
+++ b/gemfiles/rails_4.2.x.gemfile
@@ -9,5 +9,6 @@ gem "launchy"
 gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
 gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta", :platform => :jruby
 gem "rails", "~> 4.2.0"
+gem "mime-types", "< 3.0", :platform => [:mri_19]
 
 gemspec :path => "../"


### PR DESCRIPTION
mail 2.6.4 gem relaxed mime-types dependency, allowing the use of mime-types >= 3.0.

mime-types >= 3.0 requires mime-types-data gem, which requires Ruby 2.0.

This PR strengthens `mime-types` dependency for Rails 4.x Appraisals and MRI 1.9