### PR TITLE
Initialize before Rails' initialize_logger.

### DIFF
--- a/lib/rails_stdout_logging/railtie.rb
+++ b/lib/rails_stdout_logging/railtie.rb
@@ -2,7 +2,7 @@ require 'rails_stdout_logging/rails3'
 
 module RailsStdoutLogging
   class Railtie < ::Rails::Railtie
-    config.before_initialize do
+    initializer(:rails_stdout_logging, before: :initialize_logger) do
       Rails3.set_logger(config)
     end
   end

--- a/test/integration/initialization_order_test.rb
+++ b/test/integration/initialization_order_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class InitializationOrderTest < ActiveSupport::IntegrationCase
+  test 'Stderr does not contain error message' do
+    assert_no_match /Unable to access log file./, STDERR.string
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,18 @@
+require 'fileutils'
+
 # Configure Rails Envinronment
 ENV["RAILS_ENV"] = "test"
 
 DEBUG_STDOUT = STDOUT
 STDOUT = StringIO.new
+
+DEBUG_STDERR = STDERR
+STDERR = StringIO.new
+
+# triggers an error message if default logger loads and cannot write log file
+logdir = File.join(File.dirname(__FILE__), 'dummy', 'log')
+FileUtils.mkdir_p logdir
+FileUtils.chmod 'ugo-wx', logdir
 
 ENGINE_RAILS_ROOT=File.join(File.dirname(__FILE__), '../')
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)


### PR DESCRIPTION
This ensures the desired logger is configured early on, without a chance
for the default logger to complain that, for example,
`log/production.log` is not writeable.

See:
https://github.com/rails/rails/blob/3-2-stable/railties/lib/rails/application/bootstrap.rb#L24
https://github.com/rails/rails/blob/v4.2.6/railties/lib/rails/application/bootstrap.rb#L32
https://github.com/rails/rails/blob/v5.0.0/railties/lib/rails/application/bootstrap.rb#L32

Without this patch (tested in Rails 4.2.5.2), and with an unwriteable `$RAILS_ROOT/log` directory, the following error is printed when running `rails c`:

```
Rails Error: Unable to access log file. Please ensure that $RAILS_ROOT/log/development.log exists 
and is writable (ie, make it writable for user and group: chmod 0664 $RAILS_ROOT/log
/development.log). The log level has been raised to WARN and the output directed to STDERR until 
the problem is fixed.
```