### PR TITLE
Support custom log formatter

### DIFF
--- a/lib/rails_stdout_logging/rails.rb
+++ b/lib/rails_stdout_logging/rails.rb
@@ -6,9 +6,15 @@ module RailsStdoutLogging
   class Rails
     def self.heroku_stdout_logger
       logger       = StdoutLogger.new(STDOUT)
+      logger.formatter = log_formatter if log_formatter
       logger       = ActiveSupport::TaggedLogging.new(logger) if defined?(ActiveSupport::TaggedLogging)
       logger.level = StdoutLogger.const_get(log_level)
       logger
+    end
+
+    def self.log_formatter
+      config = ::Rails.application.config
+      config.respond_to?(:log_formatter) ? config.log_formatter : config.try(:logger).try(:formatter)
     end
 
     def self.log_level

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -41,5 +41,13 @@ module Dummy
 
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
+
+    require 'custom_log_formatter'
+    if defined?(config.log_formatter)
+        config.log_formatter = CustomLogFormatter.new
+    else
+        config.logger = ::Logger.new(STDOUT)
+        config.logger.formatter = CustomLogFormatter.new
+    end
   end
 end

--- a/test/dummy/lib/custom_log_formatter.rb
+++ b/test/dummy/lib/custom_log_formatter.rb
@@ -1,0 +1,5 @@
+class CustomLogFormatter
+  def call(severity, timestamp, progname, msg)
+    "[CustomLogFormatter] [#{Process.pid}] [#{severity}] [#{timestamp}] #{msg}\n"
+  end
+end

--- a/test/integration/custom_logger_test.rb
+++ b/test/integration/custom_logger_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class CustomLoggerTest < ActiveSupport::IntegrationCase
+  test 'Supports custom logger' do
+    visit bar_index_path
+    assert_match /^\[CustomLogFormatter\][^\n]+?Logging with Rails.logger$/, STDOUT.string
+  end
+end


### PR DESCRIPTION
This is hopefully a revival/fix of #21

The difference being, I am checking if Rails 3 support is needed (where `log_formatter` wasn't implemented yet) and handling it accordingly.
