### PR TITLE
Disable log buffering in rails5 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ your `production.rb` file:
 config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
 if ENV["RAILS_LOG_TO_STDOUT"].present?
+  STDOUT.sync = true
   logger           = ActiveSupport::Logger.new(STDOUT)
   logger.formatter = config.log_formatter
   config.logger = ActiveSupport::TaggedLogging.new(logger)


### PR DESCRIPTION
This behavior has been part of this gem for `rails v4`. Thus it should be added when migrating to `rails v5` in order to keep log buffering disabled.

See https://devcenter.heroku.com/articles/logging#writing-to-your-log for more details.

Fixes #31